### PR TITLE
proxy: proxy is default code generation mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,14 +98,14 @@ http:
 Rules defined this way must correspond to methods in the .proto files,
 and will overwrite any http rules defined in the proto. The path to your .yml file should be passed in as an option:
 ```groovy
- generateProtoTasks {
-            all()*.plugins {
-                grpc {}
-                jersey {
-                    option 'proxy,yaml=integration-test-base/src/test/proto/http_api_config.yml'
-                }
-            }
+generateProtoTasks {
+    all()*.plugins {
+        grpc {}
+        jersey {
+            option 'yaml=integration-test-base/src/test/proto/http_api_config.yml'
         }
+    }
+}
 ```
 or 
 ```xml
@@ -117,11 +117,28 @@ or
 
 ```
 
+## Operation modes
+
 grpc-jersey can operate in two different modes: direct invocation on service `ImplBase` or proxy via a client `Stub`.
 There are advantages and disadvantages to both, however the primary benefit to the client stub proxy is that RPCs pass
 through the same `ServerInterceptor` stack. It's recommended that the client stub passed into the Jersey resource
 uses a `InProcessTransport` if living in the same JVM as the gRPC server. A normal grpc-netty channel can be used
 for a more traditional reverse proxy.
+
+The proxy stub mode is the default as of 0.2.0.
+
+You can toggle the "direct invocation" mode by passing an option to the grpc-jersey compiler:
+
+```groovy
+generateProtoTasks {
+    all()*.plugins {
+        grpc {}
+        jersey {
+            option 'direct'
+        }
+    }
+}
+```
 
 If you plan to run "dual stack", that is, services serving traffic over both HTTP and RPC, you can configure your
 service to share resources and the same interceptor stack and avoid TCP/serialization overhead using a mixture

--- a/build.gradle
+++ b/build.gradle
@@ -335,7 +335,7 @@ project(":integration-test-serverstub") {
                         // under Windows the plugin's working dir is where the plugin is
                         yamlPathPrefix = "../../../"
                     }
-                    option "yaml=${yamlPathPrefix}integration-test-base/src/test/proto/http_api_config.yml"
+                    option "direct,yaml=${yamlPathPrefix}integration-test-base/src/test/proto/http_api_config.yml"
                 }
             }
         }
@@ -393,7 +393,7 @@ project(":integration-test-proxy") {
                         // under Windows the plugin's working dir is where the plugin is
                         yamlPathPrefix = "../../../"
                     }
-                    option "proxy,yaml=${yamlPathPrefix}integration-test-base/src/test/proto/http_api_config.yml"
+                    option "yaml=${yamlPathPrefix}integration-test-base/src/test/proto/http_api_config.yml"
                 }
             }
         }

--- a/protoc-gen-jersey/src/main/java/com/fullcontact/rpc/jersey/CodeGenerator.java
+++ b/protoc-gen-jersey/src/main/java/com/fullcontact/rpc/jersey/CodeGenerator.java
@@ -42,7 +42,7 @@ public class CodeGenerator {
             throws Descriptors.DescriptorValidationException {
         Set<String> options = Sets.newHashSet(Splitter.on(',').split(request.getParameter()));
 
-        boolean isProxy = options.contains("proxy");
+        boolean isProxy = !options.contains("direct");
 
         Map<String, Descriptors.Descriptor> lookup = new HashMap<>();
         PluginProtos.CodeGeneratorResponse.Builder response = PluginProtos.CodeGeneratorResponse.newBuilder();


### PR DESCRIPTION
Proxy mode is the recommended mode of operation for grpc-jersey, so it
should also be the default code generation mode. Users of the direct
mode often ask how to use their existing gRPC interceptors for auth, so
this should just be provided behavior.

Existing users of the `proxy` option will not need to change their
projects, `proxy` is now a no-op.

Instead, users who wish to use the server stub mode should add `direct`
to their jersey plugin options (see README).