### PR TITLE
Upgrading gradle to 4.10.3 along with several libraries and plugins.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,7 @@
 buildscript {
     repositories {
         mavenCentral()
+        jcenter()
     }
 
     apply from: file('gradle/buildscript.gradle'), to: buildscript
@@ -9,16 +10,18 @@ buildscript {
 plugins {
     id 'idea'
     id 'java'
-    id 'com.github.johnrengelman.shadow' version '1.2.2'
-    id "com.google.osdetector" version "1.4.0"
-    id 'edu.sc.seis.launch4j' version '2.4.2'
+    id 'com.github.johnrengelman.shadow' version '4.0.2'
+    id "com.google.osdetector" version "1.6.2"
+    id 'edu.sc.seis.launch4j' version '2.4.4'
+    id 'net.ltgt.apt' version '0.10'
+    id 'io.franzbecker.gradle-lombok' version '2.1'
 }
 
 ext {
-    grpcVersion = "1.8.0"
+    grpcVersion = "1.19.0"
     jerseyVersion = "2.25.1"
-    lombokVersion = "1.16.18"
-    protobufVersion = "3.5.0"
+    lombokVersion = "1.18.6"
+    protobufVersion = "3.6.1"
 }
 
 allprojects {
@@ -32,10 +35,17 @@ apply from: file('gradle/convention.gradle')
 subprojects {
     apply plugin: 'java'
     apply plugin: 'project-report'
+    apply plugin: 'net.ltgt.apt'
+
+    lombok {
+        version = "$lombokVersion"
+        sha256 = ""
+    }
 
     group = "com.xorlev.${rootProject.name}"
 
     configurations.all {
+        exclude group: 'org.slf4j', module: 'slf4j-simple'
         exclude group: 'org.slf4j', module: 'slf4j-log4j12'
         exclude group: 'log4j', module: 'log4j'
     }
@@ -64,15 +74,19 @@ subprojects {
 
     dependencies {
         provided "org.projectlombok:lombok:${lombokVersion}"
-        compile 'org.slf4j:slf4j-api:1.7.10'
+
+        compileOnly "org.projectlombok:lombok:${lombokVersion}"
+	      apt "org.projectlombok:lombok:${lombokVersion}"
+
+        compile 'org.slf4j:slf4j-api:1.7.25'
 
         testCompile "junit:junit:4.12"
         testCompile "org.assertj:assertj-core:3.1.0"
         testCompile "org.assertj:assertj-guava:3.1.0"
         testCompile "org.easymock:easymock:3.4"
         testCompile 'org.powermock:powermock-api-easymock:1.6.2'
-        testCompile('ch.qos.logback:logback-classic:1.0.13')
-        testCompile('ch.qos.logback:logback-core:1.0.13')
+        testCompile('ch.qos.logback:logback-classic:1.2.3')
+        testCompile('ch.qos.logback:logback-core:1.2.3')
     }
 }
 
@@ -89,6 +103,9 @@ project(":jersey-rpc-support") {
     }
 
     dependencies {
+        compileOnly "org.projectlombok:lombok:${lombokVersion}"
+        apt "org.projectlombok:lombok:${lombokVersion}"
+
         compile "com.google.protobuf:protobuf-java:${protobufVersion}"
         compile "com.google.protobuf:protobuf-java-util:${protobufVersion}"
         compile "io.grpc:grpc-protobuf:${grpcVersion}"
@@ -136,8 +153,8 @@ project(":protoc-gen-jersey") {
         compile "io.grpc:grpc-protobuf:${grpcVersion}"
         compile "io.grpc:grpc-stub:${grpcVersion}"
         compile "com.github.spullara.mustache.java:compiler:0.9.4"
-        compile "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.8.5"
-        compile "com.fasterxml.jackson.core:jackson-databind:2.8.5"
+        compile "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.9.7"
+        compile "com.fasterxml.jackson.core:jackson-databind:2.9.7"
 
         testCompile "org.glassfish.jersey.core:jersey-common:${jerseyVersion}"
     }
@@ -259,10 +276,10 @@ project(":integration-test-base") {
     dependencies {
         compile 'org.slf4j:jul-to-slf4j:1.7.21'
         testCompile project(':protoc-gen-jersey')
-        testCompile('io.dropwizard:dropwizard-core:1.0.5') {
+        testCompile('io.dropwizard:dropwizard-core:1.3.8') {
             exclude group: 'org.eclipse.jetty'
         }
-        testCompile('io.dropwizard:dropwizard-testing:1.0.5') {
+        testCompile('io.dropwizard:dropwizard-testing:1.3.8') {
             exclude group: 'org.eclipse.jetty'
         }
         testCompile "org.glassfish.jersey.test-framework.providers:jersey-test-framework-provider-grizzly2:${jerseyVersion}"
@@ -303,13 +320,13 @@ project(":integration-test-serverstub") {
     dependencies {
         testCompile(project(':integration-test-base').sourceSets.test.output)
         testCompile project(':protoc-gen-jersey')
-        testCompile('io.dropwizard:dropwizard-core:0.9.3') {
+        testCompile('io.dropwizard:dropwizard-core:1.3.8') {
             exclude group: 'org.eclipse.jetty'
         }
-        testCompile('io.dropwizard:dropwizard-testing:0.9.3') {
+        testCompile('io.dropwizard:dropwizard-testing:1.3.8') {
             exclude group: 'org.eclipse.jetty'
         }
-        testCompile group: 'io.dropwizard', name: 'dropwizard-jetty', version: '0.9.3'
+        testCompile group: 'io.dropwizard', name: 'dropwizard-jetty', version: '1.3.8'
         testCompile "org.glassfish.jersey.test-framework.providers:jersey-test-framework-provider-grizzly2:${jerseyVersion}"
     }
 
@@ -359,13 +376,13 @@ project(":integration-test-proxy") {
     dependencies {
         testCompile(project(':integration-test-base').sourceSets.test.output)
         testCompile project(':protoc-gen-jersey')
-        testCompile('io.dropwizard:dropwizard-core:0.9.3') {
+        testCompile('io.dropwizard:dropwizard-core:1.3.8') {
             exclude group: 'org.eclipse.jetty'
         }
-        testCompile('io.dropwizard:dropwizard-testing:0.9.3') {
+        testCompile('io.dropwizard:dropwizard-testing:1.3.8') {
             exclude group: 'org.eclipse.jetty'
         }
-        testCompile group: 'io.dropwizard', name: 'dropwizard-jetty', version: '0.9.3'
+        testCompile group: 'io.dropwizard', name: 'dropwizard-jetty', version: '1.3.8'
         testCompile "org.glassfish.jersey.test-framework.providers:jersey-test-framework-provider-grizzly2:${jerseyVersion}"
     }
 

--- a/gradle/buildscript.gradle
+++ b/gradle/buildscript.gradle
@@ -12,13 +12,13 @@ repositories {
 
 }
 dependencies {
-    classpath 'net.saliman:gradle-cobertura-plugin:1.1.2'
+    classpath 'net.saliman:gradle-cobertura-plugin:2.6.0'
     classpath 'gradle-release:gradle-release:1.1.5'
     classpath 'org.ajoberstar:gradle-git:0.5.0'
-    classpath 'com.google.guava:guava:13.0.1'
+    classpath 'com.google.guava:guava:27.0.1-jre'
     classpath 'org.apache.httpcomponents:httpcore:4.2.2'
-    classpath 'org.jfrog.buildinfo:build-info-extractor-gradle:2.2.3'
-    classpath 'commons-lang:commons-lang:2.5'
-    classpath 'com.github.jengelman.gradle.plugins:shadow:1.2.3'
-    classpath 'com.google.protobuf:protobuf-gradle-plugin:0.8.0'
+    classpath 'org.jfrog.buildinfo:build-info-extractor-gradle:4.9.3'
+    classpath 'commons-lang:commons-lang:2.6'
+    classpath 'com.github.jengelman.gradle.plugins:shadow:4.0.2'
+    classpath 'com.google.protobuf:protobuf-gradle-plugin:0.8.8'
 }

--- a/gradle/check.gradle
+++ b/gradle/check.gradle
@@ -2,43 +2,4 @@ subprojects {
     // Cobertura
     apply plugin: 'cobertura'
     cobertura.coverageFormats = ['xml', 'html']
-
-//
-//    // Checkstyle
-//    apply plugin: 'checkstyle'
-//    checkstyle {
-//        ignoreFailures = true
-//        showViolations = false
-//        configFile = rootProject.file('codequality/checkstyle.xml')
-//    }
-//
-//    // Findbugs
-//    apply plugin: 'findbugs'
-//    findbugs {
-//        excludes = ['**/thrift/*.java']
-//        ignoreFailures = true
-//    }
-//
-//    tasks.withType(FindBugs) {
-//        reports {
-//            xml.enabled = false
-//            html.enabled = true
-//        }
-//    }
-//
-//    // PMD
-//    apply plugin: 'pmd'
-//    tasks.withType(Pmd) {
-//        ignoreFailures = true
-//        reports.html.enabled true
-//        excludes = ['**/thrift/*.java']
-//    }
-//
-//    apply plugin: 'cobertura'
-//    cobertura {
-//        sourceDirs = sourceSets.main.java.srcDirs
-//        format = 'xml'
-////        includes = ['**/*.java', '**/*.groovy']
-////        excludes = ['**/thrift/*.java']
-//    }
 }

--- a/gradle/convention.gradle
+++ b/gradle/convention.gradle
@@ -9,10 +9,17 @@ if (JavaVersion.current().isJava8Compatible()) {
     }
 }
 
+
 subprojects { project ->
     apply plugin: 'java' // Plugin as major conventions
+    apply plugin: 'io.franzbecker.gradle-lombok'
 
     sourceCompatibility = 1.8
+
+    javadoc {
+      classpath = configurations.compile + configurations.compileOnly
+      // failOnError = false
+    }
 
     // Restore status after Java plugin
     status = rootProject.status
@@ -36,16 +43,6 @@ subprojects { project ->
         extendsFrom configurations.javadoc
     }
 
-    // When outputing to an Ivy repo, we want to use the proper type field
-//    gradle.taskGraph.whenReady {
-////        def isNotMaven = !it.hasTask(project.uploadMavenCentral)
-////        if (isNotMaven) {
-//            def artifacts = project.configurations.sources.artifacts
-//            def sourceArtifact = artifacts.iterator().next()
-//            sourceArtifact.type = 'sources'
-////        }
-//    }
-
     artifacts {
         sources(sourcesJar) {
             // Weird Gradle quirk where type will be used for the extension, but only for sources
@@ -67,42 +64,8 @@ subprojects { project ->
     project.sourceSets {
         main.compileClasspath += project.configurations.provided
         main.runtimeClasspath -= project.configurations.provided
+
         test.compileClasspath += project.configurations.provided
         test.runtimeClasspath += project.configurations.provided
     }
-}
-
-//apply plugin: 'github-pages' // Used to create publishGhPages task
-//
-//def docTasks = [:]
-//[Javadoc,Groovydoc].each{ Class docClass ->
-//    def allSources = allprojects.tasks*.withType(docClass).flatten()*.source
-//    if (allSources) {
-//        def shortName = docClass.simpleName.toLowerCase()
-//        def docTask = task "aggregate${shortName.capitalize()}"(type: docClass, description: "Aggregate subproject ${shortName}s") {
-//            source = allSources
-//            doFirst {
-//                def classpaths = allprojects.findAll { it.plugins.hasPlugin(JavaPlugin) }.collect { it.sourceSets.main.compileClasspath }
-//                classpath = files(classpaths)
-//            }
-//        }
-//        docTasks[shortName] = docTask
-//        processGhPages.dependsOn(docTask)
-//    }
-//}
-//
-//githubPages {
-//    repoUri = "git@github.com:fullcontact/${rootProject.name}.git"
-//    pages {
-//        docTasks.each { shortName, docTask ->
-//            from(docTask.outputs.files) {
-//                into "docs/${shortName}"
-//            }
-//        }
-//    }
-//}
-
-// Generate wrapper, which is distributed as part of source to alleviate the need of installing gradle
-task createWrapper(type: Wrapper) {
-    gradleVersion = '3.2'
 }

--- a/gradle/release.gradle
+++ b/gradle/release.gradle
@@ -27,10 +27,12 @@ release.dependsOn([forceCandidate, forceRelease])
 task releaseSnapshot(dependsOn: [uploadMaven])
 
 // Ensure our versions look like the project status before publishing
-task verifyStatus << {
-    def hasSnapshot = version.contains('-SNAPSHOT')
-    if (project.status == 'snapshot' && !hasSnapshot) {
-        throw new GradleException("Version (${version}) needs -SNAPSHOT if publishing snapshot")
+task verifyStatus {
+    doLast {
+        def hasSnapshot = version.contains('-SNAPSHOT')
+        if (project.status == 'snapshot' && !hasSnapshot) {
+            throw new GradleException("Version (${version}) needs -SNAPSHOT if publishing snapshot")
+        }
     }
 }
 uploadMaven.dependsOn(verifyStatus)

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=http\://services.gradle.org/distributions/gradle-3.2-all.zip
+distributionUrl=http\://services.gradle.org/distributions/gradle-4.10.3-all.zip

--- a/lombok.config
+++ b/lombok.config
@@ -1,0 +1,2 @@
+lombok.anyConstructor.addConstructorProperties=true
+config.stopBubbling = true


### PR DESCRIPTION
Upgrades to gradle to 4.10.3 and enables everything to compile under both JDK 8 and JDK 11. Updates several related libraries and plugins in the process and moves lombok to compileOnly (as suggested by the lombok docs for gradle 4+) instead of using the provided configuration. 

Cannot upgrade to gradle 5 until the release plugin is changed due to the leftShift deprecation.